### PR TITLE
Normalize MariaDB books SQL with genres table and database-backed views

### DIFF
--- a/book.php
+++ b/book.php
@@ -1,31 +1,41 @@
 <?php
-// Path to the JSON file
-$jsonFile = __DIR__ . '/books.json';
+// Database connection settings with environment variable overrides
+$dbHost = getenv('DB_HOST') ?: 'localhost';
+$dbPort = getenv('DB_PORT') ?: '3306';
+$dbName = getenv('DB_DATABASE') ?: 'books_db';
+$dbUser = getenv('DB_USERNAME') ?: 'root';
+$dbPass = getenv('DB_PASSWORD') ?: '';
 
-// Check if the file exists
-if (!file_exists($jsonFile)) {
-	echo "Books data file not found.";
-	exit;
-}
+$dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $dbHost, $dbPort, $dbName);
 
-// Get and decode the JSON data
-$jsonData = file_get_contents($jsonFile);
-$books = json_decode($jsonData, true);
-
-// Check for JSON errors
-if (json_last_error() !== JSON_ERROR_NONE) {
-	echo "Error reading books data.";
-	exit;
+try {
+        $pdo = new PDO($dsn, $dbUser, $dbPass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]);
+} catch (PDOException $e) {
+        echo 'Database connection failed. Please check the configuration.';
+        exit;
 }
 
 // Get book id from GET parameter
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 $book = null;
-foreach ($books as $b) {
-	if ($b['id'] === $id) {
-		$book = $b;
-		break;
-	}
+
+if ($id > 0) {
+        try {
+                $stmt = $pdo->prepare(
+                        'SELECT b.title, b.author, b.publication_year, b.image, b.pages, b.description, g.name AS genre
+                         FROM books b
+                         INNER JOIN genres g ON b.genre_id = g.id
+                         WHERE b.id = :id'
+                );
+                $stmt->execute([':id' => $id]);
+                $book = $stmt->fetch();
+        } catch (PDOException $e) {
+                echo 'Error retrieving book data.';
+                exit;
+        }
 }
 
 echo '<!DOCTYPE html>';
@@ -39,16 +49,16 @@ echo '</head>';
 echo '<body class="bg-light">';
 echo '<div class="container-fluid py-5">';
 if ($book) {
-	$name = htmlspecialchars($book['title']);
-	$author = htmlspecialchars($book['author']);
-	$image = isset($book['image']) && $book['image'] ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
-	$year = isset($book['year']) ? htmlspecialchars($book['year']) : '';
-	$genre = isset($book['genre']) ? htmlspecialchars($book['genre']) : '';
-	$pages = isset($book['pages']) ? (int)$book['pages'] : '';
-	$desc = isset($book['description']) ? htmlspecialchars($book['description']) : '';
-	echo '<div class="row justify-content-center">';
-	echo '<div class="col-12 col-md-10 col-lg-8">';
-	echo '<div class="card shadow px-4">';
+        $name = htmlspecialchars($book['title']);
+        $author = htmlspecialchars($book['author']);
+        $image = !empty($book['image']) ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
+        $year = !empty($book['publication_year']) ? htmlspecialchars((string) $book['publication_year']) : '';
+        $genre = !empty($book['genre']) ? htmlspecialchars($book['genre']) : '';
+        $pages = isset($book['pages']) ? (int) $book['pages'] : null;
+        $desc = !empty($book['description']) ? htmlspecialchars($book['description']) : '';
+        echo '<div class="row justify-content-center">';
+        echo '<div class="col-12 col-md-10 col-lg-8">';
+        echo '<div class="card shadow px-4">';
 	echo '<div class="row g-0">';
 	echo '<div class="col-md-5">';
 	echo '<img src="' . $image . '" class="img-fluid rounded-start w-100" alt="' . $name . ' cover" style="height:100%;object-fit:cover;">';
@@ -59,7 +69,7 @@ if ($book) {
 	echo '<p class="card-text mb-1"><strong>Author:</strong> ' . $author . '</p>';
 	if ($year) echo '<p class="card-text mb-1"><strong>Year:</strong> ' . $year . '</p>';
 	if ($genre) echo '<p class="card-text mb-1"><strong>Genre:</strong> ' . $genre . '</p>';
-	if ($pages) echo '<p class="card-text mb-1"><strong>Pages:</strong> ' . $pages . '</p>';
+        if (!is_null($pages) && $pages > 0) echo '<p class="card-text mb-1"><strong>Pages:</strong> ' . $pages . '</p>';
 	if ($desc) echo '<p class="card-text mt-3">' . $desc . '</p>';
 	echo '<a href="index.php" class="btn btn-primary mt-3">Back to list</a>';
 	echo '</div>';

--- a/books.sql
+++ b/books.sql
@@ -1,0 +1,45 @@
+-- Sample MariaDB script generated from books.json data
+-- Normalized to use a dedicated genres table
+
+DROP TABLE IF EXISTS `books`;
+DROP TABLE IF EXISTS `genres`;
+
+CREATE TABLE `genres` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_genres_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `books` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `title` VARCHAR(255) NOT NULL,
+  `author` VARCHAR(255) NOT NULL,
+  `publication_year` SMALLINT NOT NULL,
+  `genre_id` INT NOT NULL,
+  `image` VARCHAR(255) NOT NULL,
+  `pages` SMALLINT NOT NULL,
+  `description` TEXT NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_books_genre_id` (`genre_id`),
+  CONSTRAINT `fk_books_genre` FOREIGN KEY (`genre_id`) REFERENCES `genres` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO `genres` (`id`, `name`) VALUES
+  (1, 'Adventure'),
+  (2, 'Classic'),
+  (3, 'Dystopian'),
+  (4, 'Historical'),
+  (5, 'Romance');
+
+INSERT INTO `books` (
+  `id`, `title`, `author`, `publication_year`, `genre_id`, `image`, `pages`, `description`
+) VALUES
+  (1, '1984', 'George Orwell', 1949, 3, 'images/1984.jpg', 328, 'A dystopian novel set in a totalitarian society ruled by Big Brother, exploring themes of surveillance and control.'),
+  (2, 'The Great Gatsby', 'F. Scott Fitzgerald', 1925, 2, 'images/gatsby.jpg', 180, 'A classic novel about the mysterious Jay Gatsby and his unrelenting passion for Daisy Buchanan, set in the Roaring Twenties.'),
+  (3, 'To Kill a Mockingbird', 'Harper Lee', 1960, 2, 'images/mockingbird.jpg', 281, 'A powerful story of racial injustice and childhood innocence in the Deep South, seen through the eyes of young Scout Finch.'),
+  (4, 'Pride and Prejudice', 'Jane Austen', 1813, 5, 'images/pride.jpg', 279, 'A romantic novel that explores the themes of love, reputation, and class in 19th-century England.'),
+  (5, 'Moby-Dick', 'Herman Melville', 1851, 1, 'images/mobydick.jpg', 635, 'The epic tale of Captain Ahab''s obsessive quest to hunt the white whale, Moby-Dick.'),
+  (6, 'War and Peace', 'Leo Tolstoy', 1869, 4, 'images/warandpeace.jpg', 1225, 'A sweeping historical novel that intertwines the lives of several families during the Napoleonic Wars.'),
+  (7, 'The Catcher in the Rye', 'J.D. Salinger', 1951, 2, 'images/catcher.jpg', 214, 'A coming-of-age story about teenage alienation and rebellion, narrated by Holden Caulfield.'),
+  (8, 'Brave New World', 'Aldous Huxley', 1932, 3, 'images/bravenewworld.jpg', 268, 'A dystopian vision of a future society driven by technology, conditioning, and the loss of individuality.');

--- a/list.php
+++ b/list.php
@@ -1,20 +1,33 @@
 <?php
-// Path to the JSON file
-$jsonFile = __DIR__ . '/books.json';
+// Database connection settings with environment variable overrides
+$dbHost = getenv('DB_HOST') ?: 'localhost';
+$dbPort = getenv('DB_PORT') ?: '3306';
+$dbName = getenv('DB_DATABASE') ?: 'books_db';
+$dbUser = getenv('DB_USERNAME') ?: 'root';
+$dbPass = getenv('DB_PASSWORD') ?: '';
 
-// Check if the file exists
-if (!file_exists($jsonFile)) {
-    echo "Books data file not found.";
+$dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $dbHost, $dbPort, $dbName);
+
+try {
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (PDOException $e) {
+    echo 'Database connection failed. Please check the configuration.';
     exit;
 }
 
-// Get and decode the JSON data
-$jsonData = file_get_contents($jsonFile);
-$books = json_decode($jsonData, true);
-
-// Check for JSON errors
-if (json_last_error() !== JSON_ERROR_NONE) {
-    echo "Error reading books data.";
+try {
+    $stmt = $pdo->query(
+        'SELECT b.title, b.author, b.publication_year, b.image, g.name AS genre
+         FROM books b
+         INNER JOIN genres g ON b.genre_id = g.id
+         ORDER BY b.title'
+    );
+    $books = $stmt->fetchAll();
+} catch (PDOException $e) {
+    echo 'Error retrieving books data.';
     exit;
 }
 
@@ -30,24 +43,34 @@ echo '</head>';
 echo '<body class="bg-light">';
 echo '<div class="container py-5">';
 echo '<h1 class="mb-4 text-center">Book List</h1>';
-echo '<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">';
-foreach ($books as $book) {
-    $name = htmlspecialchars($book['title']);
-    $author = htmlspecialchars($book['author']);
-    $image = isset($book['image']) && $book['image'] ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
-    echo '<div class="col">';
-    echo '<div class="card h-100 shadow-sm">';
-    echo '<img src="' . $image . '" class="card-img-top" alt="' . $name . ' cover" style="height: 240px; object-fit: cover;">';
-    echo '<div class="card-body">';
-    echo '<h5 class="card-title">' . $name . '</h5>';
-    echo '<p class="card-text text-muted mb-1">by ' . $author . '</p>';
-    if (isset($book['year'])) echo '<p class="card-text small mb-0">Year: ' . htmlspecialchars($book['year']) . '</p>';
-    if (isset($book['genre'])) echo '<p class="card-text small text-secondary">' . htmlspecialchars($book['genre']) . '</p>';
-    echo '</div>';
-    echo '</div>';
+
+if (empty($books)) {
+    echo '<div class="alert alert-info" role="alert">No books found in the catalog.</div>';
+} else {
+    echo '<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">';
+    foreach ($books as $book) {
+        $name = htmlspecialchars($book['title']);
+        $author = htmlspecialchars($book['author']);
+        $image = !empty($book['image']) ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
+        echo '<div class="col">';
+        echo '<div class="card h-100 shadow-sm">';
+        echo '<img src="' . $image . '" class="card-img-top" alt="' . $name . ' cover" style="height: 240px; object-fit: cover;">';
+        echo '<div class="card-body">';
+        echo '<h5 class="card-title">' . $name . '</h5>';
+        echo '<p class="card-text text-muted mb-1">by ' . $author . '</p>';
+        if (!empty($book['publication_year'])) {
+            echo '<p class="card-text small mb-0">Year: ' . htmlspecialchars((string) $book['publication_year']) . '</p>';
+        }
+        if (!empty($book['genre'])) {
+            echo '<p class="card-text small text-secondary">' . htmlspecialchars($book['genre']) . '</p>';
+        }
+        echo '</div>';
+        echo '</div>';
+        echo '</div>';
+    }
     echo '</div>';
 }
-echo '</div>';
+
 echo '</div>';
 echo '</body>';
 echo '</html>';


### PR DESCRIPTION
## Summary
- add a MariaDB-compatible SQL script that creates normalized `genres` and `books` tables
- populate the tables with the sample data from books.json
- update `list.php` to read the catalog from the MariaDB schema instead of the JSON file
- update `book.php` to fetch book details from the MariaDB schema instead of the JSON file

## Testing
- php -l list.php
- php -l book.php

------
https://chatgpt.com/codex/tasks/task_b_68ceea7e66c4833396d0725bcdd6f667