### PR TITLE
Refactor book catalog to use Libro class

### DIFF
--- a/Libro.php
+++ b/Libro.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Clase que representa un libro dentro de la aplicación y ofrece
+ * métodos de utilidad para consultar el catálogo en la base de datos.
+ */
+class Libro
+{
+    private ?int $id;
+    private string $titulo;
+    private string $autor;
+    private ?int $anioPublicacion;
+    private ?string $imagen;
+    private ?string $genero;
+    private ?int $paginas;
+    private ?string $descripcion;
+
+    private const IMAGEN_POR_DEFECTO = 'https://via.placeholder.com/120x180?text=Book';
+
+    public function __construct(
+        ?int $id,
+        string $titulo,
+        string $autor,
+        ?int $anioPublicacion = null,
+        ?string $imagen = null,
+        ?string $genero = null,
+        ?int $paginas = null,
+        ?string $descripcion = null
+    ) {
+        $this->id = $id;
+        $this->titulo = $titulo;
+        $this->autor = $autor;
+        $this->anioPublicacion = $anioPublicacion;
+        $this->imagen = $imagen;
+        $this->genero = $genero;
+        $this->paginas = $paginas;
+        $this->descripcion = $descripcion;
+    }
+
+    /**
+     * Crea una instancia de Libro a partir de los datos devueltos por la BD.
+     */
+    public static function desdeArray(array $datos): self
+    {
+        $id = isset($datos['id']) && $datos['id'] !== null ? (int) $datos['id'] : null;
+        $titulo = isset($datos['title']) ? (string) $datos['title'] : '';
+        $autor = isset($datos['author']) ? (string) $datos['author'] : '';
+        $anio = isset($datos['publication_year']) && $datos['publication_year'] !== null && $datos['publication_year'] !== ''
+            ? (int) $datos['publication_year']
+            : null;
+        $imagen = isset($datos['image']) && $datos['image'] !== '' ? (string) $datos['image'] : null;
+        $genero = isset($datos['genre']) && $datos['genre'] !== '' ? (string) $datos['genre'] : null;
+        $paginas = isset($datos['pages']) && $datos['pages'] !== null && $datos['pages'] !== ''
+            ? (int) $datos['pages']
+            : null;
+        $descripcion = isset($datos['description']) && $datos['description'] !== '' ? (string) $datos['description'] : null;
+
+        return new self($id, $titulo, $autor, $anio, $imagen, $genero, $paginas, $descripcion);
+    }
+
+    /**
+     * Obtiene todos los libros almacenados en el catálogo.
+     *
+     * @return self[]
+     */
+    public static function obtenerTodos(PDO $pdo): array
+    {
+        $consulta = $pdo->query(
+            'SELECT b.id, b.title, b.author, b.publication_year, b.image, g.name AS genre
+             FROM books b
+             INNER JOIN genres g ON b.genre_id = g.id
+             ORDER BY b.title'
+        );
+
+        $libros = [];
+        while ($fila = $consulta->fetch(PDO::FETCH_ASSOC)) {
+            $libros[] = self::desdeArray($fila);
+        }
+
+        return $libros;
+    }
+
+    /**
+     * Recupera un libro concreto por su identificador o null si no existe.
+     */
+    public static function obtenerPorId(PDO $pdo, int $id): ?self
+    {
+        $sentencia = $pdo->prepare(
+            'SELECT b.id, b.title, b.author, b.publication_year, b.image, b.pages, b.description, g.name AS genre
+             FROM books b
+             INNER JOIN genres g ON b.genre_id = g.id
+             WHERE b.id = :id'
+        );
+
+        $sentencia->execute([':id' => $id]);
+        $fila = $sentencia->fetch(PDO::FETCH_ASSOC);
+
+        return $fila ? self::desdeArray($fila) : null;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitulo(): string
+    {
+        return $this->titulo;
+    }
+
+    public function getAutor(): string
+    {
+        return $this->autor;
+    }
+
+    public function getAnioPublicacion(): ?int
+    {
+        return $this->anioPublicacion;
+    }
+
+    public function getGenero(): ?string
+    {
+        return $this->genero;
+    }
+
+    public function getPaginas(): ?int
+    {
+        return $this->paginas;
+    }
+
+    public function getDescripcion(): ?string
+    {
+        return $this->descripcion;
+    }
+
+    public function getImagen(): ?string
+    {
+        return $this->imagen;
+    }
+
+    public function getImagenConFallback(): string
+    {
+        return $this->imagen ?: self::IMAGEN_POR_DEFECTO;
+    }
+}

--- a/book.php
+++ b/book.php
@@ -1,41 +1,37 @@
 <?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/Libro.php';
+
 // Database connection settings with environment variable overrides
 $dbHost = getenv('DB_HOST') ?: 'localhost';
 $dbPort = getenv('DB_PORT') ?: '3306';
-$dbName = getenv('DB_DATABASE') ?: 'books_db';
+$dbName = getenv('DB_DATABASE') ?: 'llibres';
 $dbUser = getenv('DB_USERNAME') ?: 'root';
-$dbPass = getenv('DB_PASSWORD') ?: '';
+$dbPass = getenv('DB_PASSWORD') ?: 'secret';
 
 $dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $dbHost, $dbPort, $dbName);
 
 try {
-        $pdo = new PDO($dsn, $dbUser, $dbPass, [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+    $pdo = new PDO($dsn, $dbUser, $dbPass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
 } catch (PDOException $e) {
-        echo 'Database connection failed. Please check the configuration.';
-        exit;
+    echo 'Database connection failed. Please check the configuration.';
+    exit;
 }
 
-// Get book id from GET parameter
 $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 $book = null;
 
 if ($id > 0) {
-        try {
-                $stmt = $pdo->prepare(
-                        'SELECT b.title, b.author, b.publication_year, b.image, b.pages, b.description, g.name AS genre
-                         FROM books b
-                         INNER JOIN genres g ON b.genre_id = g.id
-                         WHERE b.id = :id'
-                );
-                $stmt->execute([':id' => $id]);
-                $book = $stmt->fetch();
-        } catch (PDOException $e) {
-                echo 'Error retrieving book data.';
-                exit;
-        }
+    try {
+        $book = Libro::obtenerPorId($pdo, $id);
+    } catch (PDOException $e) {
+        echo 'Error retrieving book data.';
+        exit;
+    }
 }
 
 echo '<!DOCTYPE html>';
@@ -48,40 +44,51 @@ echo '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstra
 echo '</head>';
 echo '<body class="bg-light">';
 echo '<div class="container-fluid py-5">';
+
 if ($book) {
-        $name = htmlspecialchars($book['title']);
-        $author = htmlspecialchars($book['author']);
-        $image = !empty($book['image']) ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
-        $year = !empty($book['publication_year']) ? htmlspecialchars((string) $book['publication_year']) : '';
-        $genre = !empty($book['genre']) ? htmlspecialchars($book['genre']) : '';
-        $pages = isset($book['pages']) ? (int) $book['pages'] : null;
-        $desc = !empty($book['description']) ? htmlspecialchars($book['description']) : '';
-        echo '<div class="row justify-content-center">';
-        echo '<div class="col-12 col-md-10 col-lg-8">';
-        echo '<div class="card shadow px-4">';
-	echo '<div class="row g-0">';
-	echo '<div class="col-md-5">';
-	echo '<img src="' . $image . '" class="img-fluid rounded-start w-100" alt="' . $name . ' cover" style="height:100%;object-fit:cover;">';
-	echo '</div>';
-	echo '<div class="col-md-7">';
-	echo '<div class="card-body">';
-	echo '<h3 class="card-title">' . $name . '</h3>';
-	echo '<p class="card-text mb-1"><strong>Author:</strong> ' . $author . '</p>';
-	if ($year) echo '<p class="card-text mb-1"><strong>Year:</strong> ' . $year . '</p>';
-	if ($genre) echo '<p class="card-text mb-1"><strong>Genre:</strong> ' . $genre . '</p>';
-        if (!is_null($pages) && $pages > 0) echo '<p class="card-text mb-1"><strong>Pages:</strong> ' . $pages . '</p>';
-	if ($desc) echo '<p class="card-text mt-3">' . $desc . '</p>';
-	echo '<a href="index.php" class="btn btn-primary mt-3">Back to list</a>';
-	echo '</div>';
-	echo '</div>';
-	echo '</div>';
-	echo '</div>';
-	echo '</div>';
-	echo '</div>';
+    $name = htmlspecialchars($book->getTitulo(), ENT_QUOTES, 'UTF-8');
+    $author = htmlspecialchars($book->getAutor(), ENT_QUOTES, 'UTF-8');
+    $image = htmlspecialchars($book->getImagenConFallback(), ENT_QUOTES, 'UTF-8');
+    $year = $book->getAnioPublicacion();
+    $genre = $book->getGenero();
+    $pages = $book->getPaginas();
+    $description = $book->getDescripcion();
+
+    echo '<div class="row justify-content-center">';
+    echo '<div class="col-12 col-md-10 col-lg-8">';
+    echo '<div class="card shadow px-4">';
+    echo '<div class="row g-0">';
+    echo '<div class="col-md-5">';
+    echo '<img src="' . $image . '" class="img-fluid rounded-start w-100" alt="' . $name . ' cover" style="height:100%;object-fit:cover;">';
+    echo '</div>';
+    echo '<div class="col-md-7">';
+    echo '<div class="card-body">';
+    echo '<h3 class="card-title">' . $name . '</h3>';
+    echo '<p class="card-text mb-1"><strong>Author:</strong> ' . $author . '</p>';
+    if (!is_null($year)) {
+        echo '<p class="card-text mb-1"><strong>Year:</strong> ' . htmlspecialchars((string) $year, ENT_QUOTES, 'UTF-8') . '</p>';
+    }
+    if (!empty($genre)) {
+        echo '<p class="card-text mb-1"><strong>Genre:</strong> ' . htmlspecialchars($genre, ENT_QUOTES, 'UTF-8') . '</p>';
+    }
+    if (!is_null($pages) && $pages > 0) {
+        echo '<p class="card-text mb-1"><strong>Pages:</strong> ' . htmlspecialchars((string) $pages, ENT_QUOTES, 'UTF-8') . '</p>';
+    }
+    if (!empty($description)) {
+        echo '<p class="card-text mt-3">' . nl2br(htmlspecialchars($description, ENT_QUOTES, 'UTF-8')) . '</p>';
+    }
+    echo '<a href="list.php" class="btn btn-primary mt-3">Back to list</a>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
+    echo '</div>';
 } else {
-	echo '<div class="alert alert-danger">Book not found.</div>';
-	echo '<a href="index.php" class="btn btn-primary">Back to list</a>';
+    echo '<div class="alert alert-danger">Book not found.</div>';
+    echo '<a href="list.php" class="btn btn-primary">Back to list</a>';
 }
+
 echo '</div>';
 echo '</body>';
 echo '</html>';

--- a/list.php
+++ b/list.php
@@ -1,4 +1,8 @@
 <?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/Libro.php';
+
 // Database connection settings with environment variable overrides
 $dbHost = getenv('DB_HOST') ?: 'localhost';
 $dbPort = getenv('DB_PORT') ?: '3306';
@@ -19,13 +23,7 @@ try {
 }
 
 try {
-    $stmt = $pdo->query(
-        'SELECT b.title, b.author, b.publication_year, b.image, g.name AS genre
-         FROM books b
-         INNER JOIN genres g ON b.genre_id = g.id
-         ORDER BY b.title'
-    );
-    $books = $stmt->fetchAll();
+    $books = Libro::obtenerTodos($pdo);
 } catch (PDOException $e) {
     echo 'Error retrieving books data.';
     exit;
@@ -44,25 +42,32 @@ echo '<body class="bg-light">';
 echo '<div class="container py-5">';
 echo '<h1 class="mb-4 text-center">Book List</h1>';
 
+echo '<div class="mb-3 text-end">';
+echo '<a href="list.php" class="btn btn-outline-secondary btn-sm">Reload list</a>';
+echo '</div>';
+
 if (empty($books)) {
     echo '<div class="alert alert-info" role="alert">No books found in the catalog.</div>';
 } else {
     echo '<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">';
     foreach ($books as $book) {
-        $name = htmlspecialchars($book['title']);
-        $author = htmlspecialchars($book['author']);
-        $image = !empty($book['image']) ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
+        $name = htmlspecialchars($book->getTitulo(), ENT_QUOTES, 'UTF-8');
+        $author = htmlspecialchars($book->getAutor(), ENT_QUOTES, 'UTF-8');
+        $image = htmlspecialchars($book->getImagenConFallback(), ENT_QUOTES, 'UTF-8');
         echo '<div class="col">';
         echo '<div class="card h-100 shadow-sm">';
         echo '<img src="' . $image . '" class="card-img-top" alt="' . $name . ' cover" style="height: 240px; object-fit: cover;">';
         echo '<div class="card-body">';
         echo '<h5 class="card-title">' . $name . '</h5>';
         echo '<p class="card-text text-muted mb-1">by ' . $author . '</p>';
-        if (!empty($book['publication_year'])) {
-            echo '<p class="card-text small mb-0">Year: ' . htmlspecialchars((string) $book['publication_year']) . '</p>';
+        if (!is_null($book->getAnioPublicacion())) {
+            echo '<p class="card-text small mb-0">Year: ' . htmlspecialchars((string) $book->getAnioPublicacion(), ENT_QUOTES, 'UTF-8') . '</p>';
         }
-        if (!empty($book['genre'])) {
-            echo '<p class="card-text small text-secondary">' . htmlspecialchars($book['genre']) . '</p>';
+        if (!empty($book->getGenero())) {
+            echo '<p class="card-text small text-secondary">' . htmlspecialchars($book->getGenero(), ENT_QUOTES, 'UTF-8') . '</p>';
+        }
+        if (!is_null($book->getId())) {
+            echo '<a href="book.php?id=' . urlencode((string) $book->getId()) . '" class="btn btn-sm btn-outline-primary mt-2">View details</a>';
         }
         echo '</div>';
         echo '</div>';


### PR DESCRIPTION
## Summary
- add a reusable `Libro` class to hydrate records from the database and expose accessors
- refactor the list and detail pages to load books through the new class and improve sanitised output
- align database defaults and add links from the list to the detail page for easier navigation

## Testing
- php -l Libro.php
- php -l list.php
- php -l book.php

------
https://chatgpt.com/codex/tasks/task_b_68e52527d1508333988eb78a27ec24c8