### PR TITLE
Refactor book pages to use Book class

### DIFF
--- a/book.php
+++ b/book.php
@@ -22,16 +22,11 @@ try {
 $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 $book = null;
 
+require_once __DIR__ . '/src/Book.php';
+
 if ($id > 0) {
         try {
-                $stmt = $pdo->prepare(
-                        'SELECT b.title, b.author, b.publication_year, b.image, b.pages, b.description, g.name AS genre
-                         FROM books b
-                         INNER JOIN genres g ON b.genre_id = g.id
-                         WHERE b.id = :id'
-                );
-                $stmt->execute([':id' => $id]);
-                $book = $stmt->fetch();
+                $book = Book::findById($pdo, $id);
         } catch (PDOException $e) {
                 echo 'Error retrieving book data.';
                 exit;
@@ -48,29 +43,25 @@ echo '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstra
 echo '</head>';
 echo '<body class="bg-light">';
 echo '<div class="container-fluid py-5">';
-if ($book) {
-        $name = htmlspecialchars($book['title']);
-        $author = htmlspecialchars($book['author']);
-        $image = !empty($book['image']) ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
-        $year = !empty($book['publication_year']) ? htmlspecialchars((string) $book['publication_year']) : '';
-        $genre = !empty($book['genre']) ? htmlspecialchars($book['genre']) : '';
-        $pages = isset($book['pages']) ? (int) $book['pages'] : null;
-        $desc = !empty($book['description']) ? htmlspecialchars($book['description']) : '';
+if ($book instanceof Book) {
+        $name = htmlspecialchars($book->getTitle());
+        $author = htmlspecialchars($book->getAuthor());
+        $image = htmlspecialchars($book->getImageUrl());
         echo '<div class="row justify-content-center">';
         echo '<div class="col-12 col-md-10 col-lg-8">';
         echo '<div class="card shadow px-4">';
-	echo '<div class="row g-0">';
-	echo '<div class="col-md-5">';
-	echo '<img src="' . $image . '" class="img-fluid rounded-start w-100" alt="' . $name . ' cover" style="height:100%;object-fit:cover;">';
-	echo '</div>';
-	echo '<div class="col-md-7">';
-	echo '<div class="card-body">';
-	echo '<h3 class="card-title">' . $name . '</h3>';
-	echo '<p class="card-text mb-1"><strong>Author:</strong> ' . $author . '</p>';
-	if ($year) echo '<p class="card-text mb-1"><strong>Year:</strong> ' . $year . '</p>';
-	if ($genre) echo '<p class="card-text mb-1"><strong>Genre:</strong> ' . $genre . '</p>';
-        if (!is_null($pages) && $pages > 0) echo '<p class="card-text mb-1"><strong>Pages:</strong> ' . $pages . '</p>';
-	if ($desc) echo '<p class="card-text mt-3">' . $desc . '</p>';
+        echo '<div class="row g-0">';
+        echo '<div class="col-md-5">';
+        echo '<img src="' . $image . '" class="img-fluid rounded-start w-100" alt="' . $name . ' cover" style="height:100%;object-fit:cover;">';
+        echo '</div>';
+        echo '<div class="col-md-7">';
+        echo '<div class="card-body">';
+        echo '<h3 class="card-title">' . $name . '</h3>';
+        echo '<p class="card-text mb-1"><strong>Author:</strong> ' . $author . '</p>';
+        if ($book->hasPublicationYear()) echo '<p class="card-text mb-1"><strong>Year:</strong> ' . htmlspecialchars((string) $book->getPublicationYear()) . '</p>';
+        if ($book->hasGenre()) echo '<p class="card-text mb-1"><strong>Genre:</strong> ' . htmlspecialchars((string) $book->getGenre()) . '</p>';
+        if ($book->hasPages()) echo '<p class="card-text mb-1"><strong>Pages:</strong> ' . htmlspecialchars((string) $book->getPages()) . '</p>';
+        if ($book->hasDescription()) echo '<p class="card-text mt-3">' . htmlspecialchars((string) $book->getDescription()) . '</p>';
 	echo '<a href="index.php" class="btn btn-primary mt-3">Back to list</a>';
 	echo '</div>';
 	echo '</div>';

--- a/list.php
+++ b/list.php
@@ -18,14 +18,10 @@ try {
     exit;
 }
 
+require_once __DIR__ . '/src/Book.php';
+
 try {
-    $stmt = $pdo->query(
-        'SELECT b.title, b.author, b.publication_year, b.image, g.name AS genre
-         FROM books b
-         INNER JOIN genres g ON b.genre_id = g.id
-         ORDER BY b.title'
-    );
-    $books = $stmt->fetchAll();
+    $books = Book::fetchAll($pdo);
 } catch (PDOException $e) {
     echo 'Error retrieving books data.';
     exit;
@@ -49,20 +45,20 @@ if (empty($books)) {
 } else {
     echo '<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">';
     foreach ($books as $book) {
-        $name = htmlspecialchars($book['title']);
-        $author = htmlspecialchars($book['author']);
-        $image = !empty($book['image']) ? htmlspecialchars($book['image']) : 'https://via.placeholder.com/120x180?text=Book';
+        $name = htmlspecialchars($book->getTitle());
+        $author = htmlspecialchars($book->getAuthor());
+        $image = htmlspecialchars($book->getImageUrl());
         echo '<div class="col">';
         echo '<div class="card h-100 shadow-sm">';
         echo '<img src="' . $image . '" class="card-img-top" alt="' . $name . ' cover" style="height: 240px; object-fit: cover;">';
         echo '<div class="card-body">';
         echo '<h5 class="card-title">' . $name . '</h5>';
         echo '<p class="card-text text-muted mb-1">by ' . $author . '</p>';
-        if (!empty($book['publication_year'])) {
-            echo '<p class="card-text small mb-0">Year: ' . htmlspecialchars((string) $book['publication_year']) . '</p>';
+        if ($book->hasPublicationYear()) {
+            echo '<p class="card-text small mb-0">Year: ' . htmlspecialchars((string) $book->getPublicationYear()) . '</p>';
         }
-        if (!empty($book['genre'])) {
-            echo '<p class="card-text small text-secondary">' . htmlspecialchars($book['genre']) . '</p>';
+        if ($book->hasGenre()) {
+            echo '<p class="card-text small text-secondary">' . htmlspecialchars((string) $book->getGenre()) . '</p>';
         }
         echo '</div>';
         echo '</div>';

--- a/src/Book.php
+++ b/src/Book.php
@@ -1,0 +1,123 @@
+<?php
+
+class Book
+{
+    private const DEFAULT_IMAGE = 'https://via.placeholder.com/120x180?text=Book';
+
+    private ?int $id;
+    private string $title;
+    private string $author;
+    private ?int $publicationYear;
+    private ?string $image;
+    private ?string $genre;
+    private ?int $pages;
+    private ?string $description;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data)
+    {
+        $this->id = isset($data['id']) ? (int) $data['id'] : null;
+        $this->title = $data['title'] ?? '';
+        $this->author = $data['author'] ?? '';
+        $this->publicationYear = isset($data['publication_year']) ? (int) $data['publication_year'] : null;
+        $this->image = $data['image'] ?? null;
+        $this->genre = $data['genre'] ?? null;
+        $this->pages = isset($data['pages']) ? (int) $data['pages'] : null;
+        $this->description = $data['description'] ?? null;
+    }
+
+    public static function fetchAll(PDO $pdo): array
+    {
+        $stmt = $pdo->query(
+            'SELECT b.id, b.title, b.author, b.publication_year, b.image, g.name AS genre
+             FROM books b
+             INNER JOIN genres g ON b.genre_id = g.id
+             ORDER BY b.title'
+        );
+
+        $rows = $stmt->fetchAll();
+
+        return array_map(static fn(array $row) => new self($row), $rows);
+    }
+
+    public static function findById(PDO $pdo, int $id): ?self
+    {
+        $stmt = $pdo->prepare(
+            'SELECT b.id, b.title, b.author, b.publication_year, b.image, b.pages, b.description, g.name AS genre
+             FROM books b
+             INNER JOIN genres g ON b.genre_id = g.id
+             WHERE b.id = :id'
+        );
+
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch();
+
+        if (!$row) {
+            return null;
+        }
+
+        return new self($row);
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getAuthor(): string
+    {
+        return $this->author;
+    }
+
+    public function hasPublicationYear(): bool
+    {
+        return $this->publicationYear !== null && $this->publicationYear > 0;
+    }
+
+    public function getPublicationYear(): ?int
+    {
+        return $this->publicationYear;
+    }
+
+    public function getImageUrl(): string
+    {
+        return !empty($this->image) ? $this->image : self::DEFAULT_IMAGE;
+    }
+
+    public function hasGenre(): bool
+    {
+        return !empty($this->genre);
+    }
+
+    public function getGenre(): ?string
+    {
+        return $this->genre;
+    }
+
+    public function hasPages(): bool
+    {
+        return $this->pages !== null && $this->pages > 0;
+    }
+
+    public function getPages(): ?int
+    {
+        return $this->pages;
+    }
+
+    public function hasDescription(): bool
+    {
+        return !empty($this->description);
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `Book` class to model book records and encapsulate database queries
- refactor the list and detail views to use the new class for rendering data

## Testing
- php -l src/Book.php
- php -l book.php
- php -l list.php

------
https://chatgpt.com/codex/tasks/task_b_68e52527d1508333988eb78a27ec24c8